### PR TITLE
return to Spectrum outputs end of year aware and evertest

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: first90
-Version: 1.0-3
+Version: 1.0-4
 Title: What the Package Does (One Line, Title Case)
 Description: What the package does (one paragraph).
 Authors@R: c(person("Jeffrey", "Eaton", email = "jeffrey.eaton@imperial.ac.uk", role = c("aut", "cre")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: first90
-Version: 1.0-4
+Version: 1.1
 Title: What the Package Does (One Line, Title Case)
 Description: What the package does (one paragraph).
 Authors@R: c(person("Jeffrey", "Eaton", email = "jeffrey.eaton@imperial.ac.uk", role = c("aut", "cre")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: first90
-Version: 1.0-2
+Version: 1.0-3
 Title: What the Package Does (One Line, Title Case)
 Description: What the package does (one paragraph).
 Authors@R: c(person("Jeffrey", "Eaton", email = "jeffrey.eaton@imperial.ac.uk", role = c("aut", "cre")),

--- a/R/plot_functions.R
+++ b/R/plot_functions.R
@@ -4,13 +4,14 @@ get_pjnz_summary_data <- function(fp) {
   mod <- simmod(fp)
   start <- fp$ss$proj_start
   end <- start + fp$ss$PROJ_YEARS - 1L
+
   list(
     year = start:end,
-    pop = apply(mod[1:35,,,], 4, FUN=sum),
+    pop = apply(mod[,,,], 4, FUN=sum),
     prevalence = attr(mod, "prev15to49"),
     incidence = attr(mod, "incid15to49"),
-    plhiv = apply(attr(mod, "hivpop")[,1:8,,], 4, FUN=sum) + apply(attr(mod, "artpop")[,,1:8,,], 5, FUN=sum),
-    art_coverage = apply(attr(mod, "artpop")[,,1:8,,], 5, FUN=sum)
+    plhiv = apply(attr(mod, "hivpop")[,,,], 4, FUN=sum) + apply(attr(mod, "artpop")[,,,,], 5, FUN=sum),
+    art_coverage = colSums(fp$art15plus_num)
   )
 }
 

--- a/R/plot_outputs.R
+++ b/R/plot_outputs.R
@@ -1072,11 +1072,37 @@ tab_out_nbaware <- function(mod, fp, age_grp = '15-49', gender = 'both', year_ra
 
 #' @export
 tab_out_artcov <- function(mod, fp, gender = 'both', year_range = c(2010, 2018)) {
-  # ART coverage is already end-of-year, no need to adjust
-  if (length(year_range) == 1) { year_range <- c(year_range, year_range) }
-    out <- get_out_art(mod, fp, gender)
-    out$value <- round(out$value * 100, 1)
-    tab_artcov <- subset(out, year >= year_range[1] & year <= year_range[2])
+  ## ART coverage is already end-of-year, no need to adjust
+  
+  if (length(year_range) == 1) {
+    year_range <- c(year_range, year_range)
+  }
+
+  artcov_m <- data.frame(year = fp$ss$proj_start + seq_len(fp$ss$PROJ_YEARS) - 1L,
+                         outcome = "artcov",
+                         agegr = "15+",
+                         sex = "male",
+                         hivstatus = "positive",
+                         value = fp$art15plus_num[1,] / colSums(mod[,1,2,]))
+
+  artcov_f <- data.frame(year = fp$ss$proj_start + seq_len(fp$ss$PROJ_YEARS) - 1L,
+                         outcome = "artcov",
+                         agegr = "15+",
+                         sex = "female",
+                         hivstatus = "positive",
+                         value = fp$art15plus_num[2,] / colSums(mod[,2,2,]))
+
+  artcov_b <- data.frame(year = fp$ss$proj_start + seq_len(fp$ss$PROJ_YEARS) - 1L,
+                         outcome = "artcov",
+                         agegr = "15+",
+                         sex = "both",
+                         hivstatus = "positive",
+                         value = colSums(fp$art15plus_num) / colSums(mod[,,2,],,2))
+
+  out <- rbind(artcov_b, artcov_m, artcov_f)
+  out$value <- round(out$value * 100, 1)
+  tab_artcov <- subset(out, year >= year_range[1] & year <= year_range[2] &
+                            sex %in% gender)
   row.names(tab_artcov) <- NULL
   tab_artcov
 }

--- a/R/plot_outputs.R
+++ b/R/plot_outputs.R
@@ -984,7 +984,7 @@ plot_out_strat <- function(mod, fp, likdat, cnt, survey_hts, out_evertest, simul
 end_of_year <- function(year, value){
   if (length(unique(year)) != length(year)) { print('non unique years'); break }
   new_x <- year + 0.5
-  new_value <- approx(year, value, new_x, method = 'linear')$y
+  new_value <- approx(year, value, new_x, method = 'linear', rule = 2)$y
   return(new_value)
 } 
 


### PR DESCRIPTION
Spectrum uses PLHIV at mid-year and number on ART at end year to calculate ART coverage. In order to be consistent with interpolated end of year percentage ever test and aware by first90, and also use mid-year PLHIV denominators, `spectrum_output_table()` has been updated to return end of year number ever test and number aware as [mid-year PLHIV] x [end year aware %].