### PR TITLE
Invoking R version of pool_prb_dx() instead of pool_prb_dx_cpp()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: first90
-Version: 1.3.2
+Version: 1.3.3
 Title: The first90 model
 Description: Implements the Shiny90 model for estimating progress towards the UNAIDS "first 90" target for HIV awareness of status in sub-Saharan Africa.
 Authors@R:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# first90 1.3.3
+
+* Output the proportion of the undiagnosed population who were infected 
+  in the past year in the Spectrum outputs download.
+
 # first90 0.0.0.9000
 
 * Added a `NEWS.md` file to track changes to the package.

--- a/R/table_output.R
+++ b/R/table_output.R
@@ -47,27 +47,25 @@ spectrum_output_table <- function(mod, fp) {
   aware <- cbind(aware_m = aware_m$value,
                  aware_f = aware_f$value) * plhiv
   
-  ## # Number adults 15+ undiagnosed and infected in the past year
-  ## prb_dx_1yr_m <- pool_prb_dx_one_yr(mod, fp, year = c(2000:2019),
-  ##                  age = c("15-24","25-34", "35-49", "50-99"),
-  ##                  sex = c("male"))
-  ## prb_dx_1yr_f <- pool_prb_dx_one_yr(mod, fp, year = c(2000:2019),
-  ##                  age = c("15-24","25-34", "35-49", "50-99"),
-  ##                  sex = c("female"))
-  ## prb_dx_1yr <- cbind(prb_dx_1yr_m = c(prb_dx_1yr_m$prb1yr, 
-  ##                                      rep(NA, length(year_out) - nrow(prb_dx_1yr_m))),
-  ##                     prb_dx_1yr_f = c(prb_dx_1yr_f$prb1yr, 
-  ##                                      rep(NA, length(year_out) - nrow(prb_dx_1yr_m)))) 
-  ## new_inf_m <- apply(fp$infections[, 1, out_idx], MARGIN = 2, FUN = sum)
-  ## new_inf_f <- apply(fp$infections[, 2, out_idx], MARGIN = 2, FUN = sum)
+  # Number adults 15+ undiagnosed and infected in the past year
+  prb_dx_1yr_m <- pool_prb_dx_one_yr(mod, fp, year = c(2000:2019),
+                    age = c("15-24","25-34", "35-49", "50-99"),
+                    sex = c("male"))
+  prb_dx_1yr_f <- pool_prb_dx_one_yr(mod, fp, year = c(2000:2019),
+                    age = c("15-24","25-34", "35-49", "50-99"),
+                    sex = c("female"))
+  prb_dx_1yr <- cbind(prb_dx_1yr_m = c(prb_dx_1yr_m$prb1yr, 
+                                        rep(NA, length(year_out) - nrow(prb_dx_1yr_m))),
+                       prb_dx_1yr_f = c(prb_dx_1yr_f$prb1yr, 
+                                        rep(NA, length(year_out) - nrow(prb_dx_1yr_m)))) 
+  new_inf_m <- apply(fp$infections[, 1, out_idx], MARGIN = 2, FUN = sum)
+  new_inf_f <- apply(fp$infections[, 2, out_idx], MARGIN = 2, FUN = sum)
 
-  ## notdx_hiv_one_yr_m <- new_inf_m * (1 - prb_dx_1yr[, "prb_dx_1yr_m"])
-  ## notdx_hiv_one_yr_f <- new_inf_f * (1 - prb_dx_1yr[, "prb_dx_1yr_f"])
+  notdx_hiv_one_yr_m <- new_inf_m * (1 - prb_dx_1yr[, "prb_dx_1yr_m"])
+  notdx_hiv_one_yr_f <- new_inf_f * (1 - prb_dx_1yr[, "prb_dx_1yr_f"])
   
-  ## notdx_hiv_one_yr <- cbind(notdx_hiv_one_yr_m, notdx_hiv_one_yr_f) 
+  notdx_hiv_one_yr <- cbind(notdx_hiv_one_yr_m, notdx_hiv_one_yr_f) 
 
-  notdx_hiv_one_yr <- cbind(notdx_hiv_one_yr_m = 0, notdx_hiv_one_yr_f = 0)
-  
   data.frame(year = year_out,
              plhiv,
              evertest,

--- a/R/time_functions.R
+++ b/R/time_functions.R
@@ -3,7 +3,7 @@
 
 #  Function to calculate outputs by age / sex / testing history stratifications
 #' @export
-prb_dx_one_yr <- function(fp, year = c(2000:2019), age = "15-24", sex = "male", test_ever = "never", dt = 0.1, version = "C") {
+prb_dx_one_yr <- function(fp, year = c(2000:2019), age = "15-24", sex = "male", test_ever = "never", dt = 0.1, version = "R") {
   
   if (version == "C") {
     val <- prb_dx_one_yr_cpp(fp, year = year, age = age, sex = sex, test_ever = test_ever, dt = dt)


### PR DESCRIPTION
Now directing the wrapper function to call the R version instead of the C++ one.
The function to output the csv table has also been updated to bring back the estimates of the number of new infections not diagnosed within one year.