### PR TITLE
Fixing kos<art in spectrum_table_output()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: first90
-Version: 1.3.3
+Version: 1.3.4
 Title: The first90 model
 Description: Implements the Shiny90 model for estimating progress towards the UNAIDS "first 90" target for HIV awareness of status in sub-Saharan Africa.
 Authors@R:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,14 @@
+# first90 1.3.4
+
+* Add adjustment in Spectrum output CSV that the number aware of status is
+  greater than the number on ART. This occurs in some cases when the 
+  'internal' number on ART in Spectrum is greater than the input end of
+  year numbers due to capping the number on ART below number of PLHIV 
+  within age/sex strata.  This also means that if the number on ART 
+  in Spectrum is greater than the number of PLHIV, then the number aware
+  will also be greater than the number of PLHIV. (This occurs seldomly,
+  but can occur.)
+
 # first90 1.3.3
 
 * Output the proportion of the undiagnosed population who were infected 

--- a/R/table_output.R
+++ b/R/table_output.R
@@ -12,6 +12,8 @@
 #'
 #' PLHIV is mid-year estimate. All other outcomes are end of year estimate.
 #'
+#' @export
+#'
 #' @examples
 #'
 #' \dontrun{
@@ -19,7 +21,7 @@
 #'           "~/Downloads/Malawi-shiny90-example-output.csv", 
 #'            row.names = FALSE)
 #' }
-#' @export 
+#'
 spectrum_output_table <- function(mod, fp) {
 
   aware_m <- get_out_aware(mod, fp, "15+", "male")

--- a/R/table_output.R
+++ b/R/table_output.R
@@ -41,7 +41,15 @@ spectrum_output_table <- function(mod, fp) {
 
   onart <- t(fp$art15plus_num[, out_idx])
   colnames(onart) <- paste0("onart_", c("m", "f"))
-
+  
+  #'  If we use the numbers on ART in mod (that get capped) all is fine.
+  #'  We do not have the situation where kos < art
+  #'  The code below verifies this...
+      # onart_f <- colSums(attr(mod, "artpop")[, , 1:9, 2, out_idx, drop = FALSE], , 4)
+      # onart_m <- colSums(attr(mod, "artpop")[, , 1:9, 1, out_idx, drop = FALSE], , 4)
+      # onart <- cbind(onart_m, onart_f)
+      # colnames(onart) <- paste0("onart_", c("m", "f"))
+  
   evertest <- cbind(evertest_m = evertest_m$value,
                     evertest_f = evertest_f$value) * plhiv
   aware <- cbind(aware_m = aware_m$value,
@@ -49,15 +57,15 @@ spectrum_output_table <- function(mod, fp) {
   
   # Number adults 15+ undiagnosed and infected in the past year
   prb_dx_1yr_m <- pool_prb_dx_one_yr(mod, fp, year = c(2000:2019),
-                    age = c("15-24","25-34", "35-49", "50-99"),
-                    sex = c("male"))
+                   age = c("15-24","25-34", "35-49", "50-99"),
+                   sex = c("male"))
   prb_dx_1yr_f <- pool_prb_dx_one_yr(mod, fp, year = c(2000:2019),
-                    age = c("15-24","25-34", "35-49", "50-99"),
-                    sex = c("female"))
+                   age = c("15-24","25-34", "35-49", "50-99"),
+                   sex = c("female"))
   prb_dx_1yr <- cbind(prb_dx_1yr_m = c(prb_dx_1yr_m$prb1yr, 
-                                        rep(NA, length(year_out) - nrow(prb_dx_1yr_m))),
-                       prb_dx_1yr_f = c(prb_dx_1yr_f$prb1yr, 
-                                        rep(NA, length(year_out) - nrow(prb_dx_1yr_m)))) 
+                                       rep(NA, length(year_out) - nrow(prb_dx_1yr_m))),
+                      prb_dx_1yr_f = c(prb_dx_1yr_f$prb1yr, 
+                                       rep(NA, length(year_out) - nrow(prb_dx_1yr_m)))) 
   new_inf_m <- apply(fp$infections[, 1, out_idx], MARGIN = 2, FUN = sum)
   new_inf_f <- apply(fp$infections[, 2, out_idx], MARGIN = 2, FUN = sum)
 
@@ -65,11 +73,24 @@ spectrum_output_table <- function(mod, fp) {
   notdx_hiv_one_yr_f <- new_inf_f * (1 - prb_dx_1yr[, "prb_dx_1yr_f"])
   
   notdx_hiv_one_yr <- cbind(notdx_hiv_one_yr_m, notdx_hiv_one_yr_f) 
-
-  data.frame(year = year_out,
+  
+  val <- data.frame(year = year_out,
              plhiv,
              evertest,
              aware,
              onart,
              notdx_hiv_one_yr)
+  
+  #' If the numbers aware are lower than those on ART, we make them equal before
+  #' importing back in Spectrum. This is necessary if countries overestimate their
+  #' ART numbers... if that is the case, Spectrum will cap initiations if there are 
+  #' not enough people to be initiated (based on sex, age, cd4 strata). Here, we are
+  #' just making the numbers equal but countries should be strongly encouraged to 
+  #' revisit their ART numbers.
+  val$aware_m <- ifelse(val$aware_m < val$onart_m, val$onart_m, val$aware_m)
+  val$aware_f <- ifelse(val$aware_f < val$onart_f, val$onart_f, val$aware_f)
+  val$evertest_m <- ifelse(val$evertest_m < val$onart_m, val$onart_m, val$evertest_m)
+  val$evertest_f <- ifelse(val$evertest_f < val$onart_f, val$onart_f, val$evertest_f)  
+  
+  return(val)
 }

--- a/R/table_output.R
+++ b/R/table_output.R
@@ -44,9 +44,9 @@ spectrum_output_table <- function(mod, fp) {
   onart <- t(fp$art15plus_num[, out_idx])
   colnames(onart) <- paste0("onart_", c("m", "f"))
   
-  #'  If we use the numbers on ART in mod (that get capped) all is fine.
-  #'  We do not have the situation where kos < art
-  #'  The code below verifies this...
+  ##  If we use the numbers on ART in mod (that get capped) all is fine.
+  ##  We do not have the situation where kos < art
+  ##  The code below verifies this...
       # onart_f <- colSums(attr(mod, "artpop")[, , 1:9, 2, out_idx, drop = FALSE], , 4)
       # onart_m <- colSums(attr(mod, "artpop")[, , 1:9, 1, out_idx, drop = FALSE], , 4)
       # onart <- cbind(onart_m, onart_f)
@@ -83,12 +83,12 @@ spectrum_output_table <- function(mod, fp) {
              onart,
              notdx_hiv_one_yr)
   
-  #' If the numbers aware are lower than those on ART, we make them equal before
-  #' importing back in Spectrum. This is necessary if countries overestimate their
-  #' ART numbers... if that is the case, Spectrum will cap initiations if there are 
-  #' not enough people to be initiated (based on sex, age, cd4 strata). Here, we are
-  #' just making the numbers equal but countries should be strongly encouraged to 
-  #' revisit their ART numbers.
+  ## If the numbers aware are lower than those on ART, we make them equal before
+  ## importing back in Spectrum. This is necessary if countries overestimate their
+  ## ART numbers... if that is the case, Spectrum will cap initiations if there are 
+  ## not enough people to be initiated (based on sex, age, cd4 strata). Here, we are
+  ## just making the numbers equal but countries should be strongly encouraged to 
+  ## revisit their ART numbers.
   val$aware_m <- ifelse(val$aware_m < val$onart_m, val$onart_m, val$aware_m)
   val$aware_f <- ifelse(val$aware_f < val$onart_f, val$onart_f, val$aware_f)
   val$evertest_m <- ifelse(val$evertest_m < val$onart_m, val$onart_m, val$evertest_m)

--- a/man/spectrum_output_table.Rd
+++ b/man/spectrum_output_table.Rd
@@ -30,4 +30,14 @@ write.csv(spectrum_output_table(mod, fp),
           "~/Downloads/Malawi-shiny90-example-output.csv", 
            row.names = FALSE)
 }
+
+ If we use the numbers on ART in mod (that get capped) all is fine.
+ We do not have the situation where kos < art
+ The code below verifies this...
+If the numbers aware are lower than those on ART, we make them equal before
+importing back in Spectrum. This is necessary if countries overestimate their
+ART numbers... if that is the case, Spectrum will cap initiations if there are 
+not enough people to be initiated (based on sex, age, cd4 strata). Here, we are
+just making the numbers equal but countries should be strongly encouraged to 
+revisit their ART numbers.
 }

--- a/man/spectrum_output_table.Rd
+++ b/man/spectrum_output_table.Rd
@@ -31,13 +31,4 @@ write.csv(spectrum_output_table(mod, fp),
            row.names = FALSE)
 }
 
- If we use the numbers on ART in mod (that get capped) all is fine.
- We do not have the situation where kos < art
- The code below verifies this...
-If the numbers aware are lower than those on ART, we make them equal before
-importing back in Spectrum. This is necessary if countries overestimate their
-ART numbers... if that is the case, Spectrum will cap initiations if there are 
-not enough people to be initiated (based on sex, age, cd4 strata). Here, we are
-just making the numbers equal but countries should be strongly encouraged to 
-revisit their ART numbers.
 }


### PR DESCRIPTION
In the spectrum table output, obtained from `spectrum_table_output()`, it is possible that the numbers aware are lower than those on ART. This is because we are using `fp$art15plus_num` but Spectrum cap the initiations if there aren't enough PLHIV to treat. So internally, we are using `attr(mod, "artpop")` that has sometime slightly different numbers. 

If that is the case, the suggestion is to make the numbers with KOS equal to that on ART... but only in this output table. All others outputs will be based on ART coverage from `attr(mod, "artpop")`. If we see that the numbers are equal,  countries should be strongly encouraged to revisit their ART numbers.

Mathieu