### PR TITLE
update retest calculation among HIV positive

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: first90
-Version: 1.3.4
+Version: 1.3.5
 Title: The first90 model
 Description: Implements the Shiny90 model for estimating progress towards the UNAIDS "first 90" target for HIV awareness of status in sub-Saharan Africa.
 Authors@R:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,14 @@
+# first90 1.3.5
+
+* Updated the calculation of 'retests' among HIV positive adults to include HIV positive
+  tests conducted amongst adults who had previously tested HIV negative. Previously new
+  HIV diagnoses were excluded from the count of retests and only HIV positive adults who 
+  were previously diagnosed or on ART were counted as 'retests'.  This should not change
+  any of the standard displayed outputs because by convention the 'retest' figures have
+  focused on retests among HIV negative adults while separate results have been reported
+  for retesting among HIV positive results.
+
+
 # first90 1.3.4
 
 * Add adjustment in Spectrum output CSV that the number aware of status is

--- a/R/retest.R
+++ b/R/retest.R
@@ -71,6 +71,7 @@ number_retests <- function(mod, fp, df){
         sum(attr(mod, "late_diagnoses")[, haidx, sidx, df$yidx[i]])
       
       retests[i] <- retests[i] +
+        sum(testneg_ha_hm * c(fp$diagn_rate[ , haidx, sidx, 2, df$yidx[i]])) +
         sum(diagn_ha_hm * c(fp$diagn_rate[ , haidx, sidx, 3, df$yidx[i]])) +
         sum(artpop_ha_hm * c(fp$diagn_rate[ , haidx, sidx, 4, df$yidx[i]]))
       


### PR DESCRIPTION
This PR updates the calculation of retests among HIV positive adults to include persons who have been previously tested when HIV negative.

The 'unaware' outcome to number_retests records the total number of new diagnoses (including those who were previously tested negative and first time tested).