### PR TITLE
make parameter vector backward compatible

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: first90
-Version: 1.4.1
+Version: 1.4.2
 Title: The first90 model
 Description: Implements the Shiny90 model for estimating progress towards the UNAIDS "first 90" target for HIV awareness of status in sub-Saharan Africa.
 Authors@R:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# first90 1.4.2
+
+* Implement backward compatibility for simulating previous .shiny90 outputs.
+  * The updates for each year add an additional knot, which changes the length
+    of the parameter vector. This update parses the knot definition based on 
+    the number of parameters.
+  * Function `create_hts_param()` will throw and error if an unexpected parameter
+    vector length is identified. 
+  
 # first90 1.4.1
 
 Updates for 2021 UNAIDS estimates:

--- a/R/create_hts_param.R
+++ b/R/create_hts_param.R
@@ -24,9 +24,32 @@ create_hts_param <- function(theta, fp) {
     
 ## We name the parameters to be fitted
   ## Every year new estimates are produced, we need to add one knot
+  ## 
+  ## # HOTFIX 14 Dec 2020:
+  ##   * Adding knots each year makes software incompatible with .shiny90.zip
+  ##     outputs saved with previous version.
+  ##   * There is not reliable information about which version saved easily
+  ##     accessible to what gets passed through here.
+  ##   * Hotfix: use the length of the parameter vector to determine which
+  ##     year and number of knots.
+  ##     * THIS WILL FAIL if other parameters are changed.
+  ##       * Added a pretty rigid check on length of parameter vector in the
+  ##         block below.
+  ##       * Added package test to ensure we know if something changes.
+  ##
   ## -- UPDATE HERE --
-  knots <- c(1995, 2000:2021) - fp$ss$proj_start + 1L
-  knots_rr_dxunt <- c(2010:2021) - fp$ss$proj_start + 1L
+  max_knot_year <- if (length(theta) == 41) {
+                     2019
+                   } else if (length(theta) == 43) {
+                     2020
+                   } else if (length(theta) == 45) {
+                     2021
+                   } else {
+                     stop("Unexpected length of parameter vector.")
+                   }
+  
+  knots <- c(1995, 2000:max_knot_year) - fp$ss$proj_start + 1L
+  knots_rr_dxunt <- c(2010:max_knot_year) - fp$ss$proj_start + 1L
   
   ## -- UPDATE ABOVE --
   


### PR DESCRIPTION
This PR:

* Uses the parameter vector length to infer the number of knots for the annual HTS random walk.
  * This enables backward compatibility with previous .shiny90 digest files.
* Function `create_hts_param()` will throw and error if an unexpected parameter vector length is encountered. 
   * This provides some protection against future backwards compatibility breaking changes because it will 
      throw an error early rather than return spurious results.

Later I will add a test against the three versions of .shiny90 digest supported (2019, 2020, 2021).

Next year I anticipate we will rewrite this code from ground up, so hesitant to invest in a larger refactor right now.


    