### PR TITLE
bug fixes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: first90
-Version: 1.4.2
+Version: 1.4.3
 Title: The first90 model
 Description: Implements the Shiny90 model for estimating progress towards the UNAIDS "first 90" target for HIV awareness of status in sub-Saharan Africa.
 Authors@R:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# first90 1.4.3
+
+* Patch: in function `add_ss_indices()`, add argument `type.convert(..., as.is = TRUE)` 
+  to suppress R 4.0 warning.
+* Bugfix: remove duplicate declaration of `double incrate_g[NG];` in `EPP_DIRECTINCID` incidence
+  option. This did not affect any results because this option is not used in Shiny90 application; 
+  new infections by sex and age group were directly specified (option `EPP_DIRECTINFECTIONS`).
+
 # first90 1.4.2
 
 * Implement backward compatibility for simulating previous .shiny90 outputs.

--- a/R/inputs.R
+++ b/R/inputs.R
@@ -202,8 +202,8 @@ add_ss_indices <- function(dat, ss) {
   ## Convert 15+ to 15-99 for parsing below
   agegr_tmp <- sub("15\\+", "15-99", df$agegr)
   
-  df$agestart <- type.convert(sub("([0-9]+)-([0-9]+)", "\\1", agegr_tmp))
-  ageend <- type.convert(sub("([0-9]+)-([0-9]+)", "\\2", agegr_tmp))+1L
+  df$agestart <- type.convert(sub("([0-9]+)-([0-9]+)", "\\1", agegr_tmp), as.is = TRUE)
+  ageend <- type.convert(sub("([0-9]+)-([0-9]+)", "\\2", agegr_tmp), as.is = TRUE)+1L
 
   df$aidx <- df$agestart - ss$AGE_START + 1L
   df$agspan <- ageend - df$agestart

--- a/src/eppasm.cpp
+++ b/src/eppasm.cpp
@@ -979,7 +979,6 @@ extern "C" {
 	// double prev_i = Xhivp / (Xhivn[MALE] + Xhivn[FEMALE] + Xhivp);
 	// double incrate15to49_i = (prev15to49[t] - prev_i)/(1.0 - prev_i);
 	double incrate_i = incidinput[t];
-	double incrate_g[NG];
 	incrate_g[MALE] = incrate_i * (Xhivn[MALE]+Xhivn[FEMALE]) / (Xhivn[MALE] + incrr_sex[t]*Xhivn[FEMALE]);
 	incrate_g[FEMALE] = incrate_i * incrr_sex[t]*(Xhivn[MALE]+Xhivn[FEMALE]) / (Xhivn[MALE] + incrr_sex[t]*Xhivn[FEMALE]);
       }


### PR DESCRIPTION
This has a small patch and small bug fix:

* Patch: in function `add_ss_indices()`, add argument `type.convert(..., as.is = TRUE)` 
  to suppress R 4.0 warning.
* Bugfix: remove duplicate declaration of `double incrate_g[NG];` in `EPP_DIRECTINCID` incidence
  option. This did not affect any results because this option is not used in Shiny90 application; 
  new infections by sex and age group were directly specified (option `EPP_DIRECTINFECTIONS`).  (Thanks to @rlglaubius) 