### PR TITLE
patches related to EPP-ASM

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: first90
-Version: 1.6.1
+Version: 1.6.2
 Title: The first90 model
 Description: Implements the Shiny90 model for estimating progress towards the UNAIDS "first 90" target for HIV awareness of status in sub-Saharan Africa.
 Authors@R:
@@ -32,7 +32,8 @@ Imports:
     mvtnorm,
     Matrix,
     fastmatch (>= 1.1),
-    Rcpp
+    Rcpp,
+    vroom
 LinkingTo:
     BH,
     Rcpp

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# first90 1.6.2
+
+* Use `vroom::vroom()` to read PJNZ files; much faster for reading `.DP` file.
 # first90 1.6.1
 
 Updates for 2023 UNAIDS estimates:

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 * Handle Spectrum version numbers saved on Francophone locale devices: e.g. 6,13 instead of 6.13.
 * In `read_specdp_demog_param()`, ensure no zero totals when normalising age-specific fertility 
   distribution and net-migration age distribution.
+* Fix calculation for target number on treatment during transition from number to percent input.
+
 # first90 1.6.1
 
 Updates for 2023 UNAIDS estimates:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # first90 1.6.2
 
 * Use `vroom::vroom()` to read PJNZ files; much faster for reading `.DP` file.
+* Handle Spectrum version numbers saved on Francophone locale devices: e.g. 6,13 instead of 6.13.
 # first90 1.6.1
 
 Updates for 2023 UNAIDS estimates:

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * Use `vroom::vroom()` to read PJNZ files; much faster for reading `.DP` file.
 * Handle Spectrum version numbers saved on Francophone locale devices: e.g. 6,13 instead of 6.13.
+* In `read_specdp_demog_param()`, ensure no zero totals when normalising age-specific fertility 
+  distribution and net-migration age distribution.
 # first90 1.6.1
 
 Updates for 2023 UNAIDS estimates:

--- a/R/create_fp.R
+++ b/R/create_fp.R
@@ -59,6 +59,9 @@ create_fp <- function(projp,
   fp$SIM_YEARS <- ss$PROJ_YEARS
   fp$proj.steps <- proj_start + 0.5 + 0:(ss$hiv_steps_per_year * (fp$SIM_YEARS-1)) / ss$hiv_steps_per_year
 
+  ## Replace 6,14 with 6.14 for files saved with french locale
+  projp$spectrum_version <- sub("^([0-9]+),(.*)$", "\\1.\\2", projp$spectrum_version)
+  
   if (!grepl("^[4-6]\\.[0-9]", projp$spectrum_version)) {
     stop(paste0("Spectrum version not recognized: ", projp$spectrum_version))
   }

--- a/R/eppasm.R
+++ b/R/eppasm.R
@@ -366,7 +366,7 @@ simmod <- function(fp, VERSION = "C"){
               artnum.ii[g] <- artcov.ii * (sum(art15plus.elig[,,g]) + sum(artpop[,,h.age15plus.idx,g,i]))
             } else if(!fp$art15plus_isperc[g,i-1] & fp$art15plus_isperc[g,i]){  # transition number to percentage
               curr_coverage <- sum(artpop[,,h.age15plus.idx,g,i]) / (sum(art15plus.elig[,,g]) + sum(artpop[,,h.age15plus.idx,g,i]))
-              artcov.ii <- curr_coverage + (fp$art15plus_num[g,i] - curr_coverage) * DT/(1.0 - art_interp_w)
+              artcov.ii <- curr_coverage + (fp$art15plus_num[g,i] - curr_coverage) * DT/(1.0 - art_interp_w + DT)
               artnum.ii[g] <- artcov.ii * (sum(art15plus.elig[,,g]) + sum(artpop[,,h.age15plus.idx,g,i]))
             }
           }

--- a/R/extract-pjnz.R
+++ b/R/extract-pjnz.R
@@ -2,7 +2,7 @@
 first90_read_csv_character <- function(file) {
   v <- vroom::vroom(file, delim = ",",
                     col_types = vroom::cols(.default = vroom::col_character()),
-                    .name_repair = "minimal")
+                    .name_repair = "minimal", progress = FALSE)
   v <- as.data.frame(v)
   v
 }

--- a/R/extract-pjnz.R
+++ b/R/extract-pjnz.R
@@ -665,7 +665,9 @@ get_dp_artmx_timerr <- function(dp, proj_years){
 calc_asfr <- function(tfr, asfd){
 
   ## Normalise the ASFD to sum exactly to 1.0
-  asfd <- sweep(asfd, 2, colSums(asfd), "/")
+  asfd_sum <- colSums(asfd)
+  asfd_sum[asfd_sum == 0.0] <- 1.0
+  asfd <- sweep(asfd, 2, asfd_sum, "/")
   
   asfr <- apply(asfd / 5, 2, rep, each=5)
   asfr <- sweep(asfr, 2, tfr, "*")
@@ -677,7 +679,9 @@ calc_asfr <- function(tfr, asfd){
 calc_netmigr <- function(totnetmig, netmigagedist, Sx){
 
   ## Normalise netmigagedist to sum to exactly 1.0
-  netmigagedist <- sweep(netmigagedist, 2:3, colSums(netmigagedist), "/")
+  netmigagedist_sum <- colSums(netmigagedist)
+  netmigagedist_sum[netmigagedist_sum == 0.0] <- 1.0
+  netmigagedist <- sweep(netmigagedist, 2:3, netmigagedist_sum, "/")
   
   netmigr5 <- sweep(netmigagedist, 2:3, totnetmig, "*")
   A <- create_beers(17)

--- a/R/extract-pjnz.R
+++ b/R/extract-pjnz.R
@@ -44,6 +44,11 @@ extract_pjnz <- function(pjnz = NULL, dp_file= NULL, pjn_file = NULL){
   v$projection_name <- pjn[which(pjn[,1] == "<Projection Name>")+2, 4]
   v$spectrum_version <- pjn[which(pjn[,1] == "<Projection General>")+4, 4]
 
+  ## Replace comma decimal separator save on Francophone locale computers
+  ## (e.g. replace 6,14 by 6.14
+  v$spectrum_version <- sub("^([0-9]+),(.*)$", "\\1.\\2", v$spectrum_version)
+
+
   v$valid_date <- dpsub(dp, "<ValidDate MV>", 2, 3)
 
   ## Spectrum custom population used

--- a/R/extract-pjnz.R
+++ b/R/extract-pjnz.R
@@ -1,4 +1,11 @@
 
+first90_read_csv_character <- function(file) {
+  v <- vroom::vroom(file, delim = ",",
+                    col_types = vroom::cols(.default = vroom::col_character()),
+                    .name_repair = "minimal")
+  v <- as.data.frame(v)
+  v
+}
 
 #' Extract outputs from PJNZ needed for first90 model
 #'
@@ -19,8 +26,8 @@ extract_pjnz <- function(pjnz = NULL, dp_file= NULL, pjn_file = NULL){
   else if(is.null(pjnz) && (is.null(dp_file) || is.null(pjn_file)))
     stop("Must provide either a Spectrum .PJNZ file or both a .DP and .PJN file")
 
-  dp <- read.csv(dp_file, as.is = TRUE)
-  pjn <- read.csv(pjn_file, as.is = TRUE)
+  dp <- first90_read_csv_character(dp_file)
+  pjn <- first90_read_csv_character(pjn_file)
 
 
   year_start <- as.integer(dpsub(dp, "<FirstYear MV2>",2,4))
@@ -692,7 +699,7 @@ calc_netmigr <- function(totnetmig, netmigagedist, Sx){
 #' Get country name from parsed PJN
 #' @param pjn parsed PJN file
 #' @details
-#' `pjn` should be via `read.csv(pjn_file, as.is = TRUE)`
+#' `pjn` should be via `first90_read_csv_character(pjn_file)`
 #' @export
 get_pjn_country <- function(pjn){
   cc <- as.integer(pjn[which(pjn[, 1] == "<Projection Parameters>") + 2, 4])
@@ -703,11 +710,11 @@ get_pjn_country <- function(pjn){
 #' Get subnational region from parsed PJN
 #' @param pjn parsed PJN file
 #' @details
-#' `pjn` should be via `read.csv(pjn_file, as.is = TRUE)`
+#' `pjn` should be via `first90_read_csv_character(pjn_file)`
 #' @export
 get_pjn_region <- function(pjn){
   region <- pjn[which(pjn[, 1] == "<Projection Parameters - Subnational Region Name2>") + 2, 4]
-  if (region == "") 
+  if (is.na(region) || region == "") 
     return(NULL)
   else
     return(region)
@@ -733,7 +740,7 @@ read_country <- function(pjnz = NULL, pjn_file = NULL){
   else if(!is.null(pjnz) && !is.null(pjn_file))
     stop("Must provide either a Spectrum .PJNZ file or a .PJN file. Do not provide both.")
 
-  pjn <- read.csv(pjn_file, as.is = TRUE)
+  pjn <- first90_read_csv_character(pjn_file)
   get_pjn_country(pjn)
 }
 
@@ -745,6 +752,6 @@ read_region <- function(pjnz = NULL, pjn_file = NULL){
   else if(!is.null(pjnz) && !is.null(pjn_file))
     stop("Must provide either a Spectrum .PJNZ file or a .PJN file. Do not provide both.")
 
-  pjn <- read.csv(pjn_file, as.is = TRUE)
+  pjn <- first90_read_csv_character(pjn_file)
   get_pjn_region(pjn)
 }

--- a/src/eppasm.cpp
+++ b/src/eppasm.cpp
@@ -808,7 +808,7 @@ extern "C" {
                 artnum_hts = artcov_hts * (Xart_15plus + Xartelig_15plus);
               } else if(!art15plus_isperc[t-1][g] && art15plus_isperc[t][g]){ // transition from number to percentage
                 double curr_coverage = Xart_15plus / (Xart_15plus + Xartelig_15plus);
-		double artcov_hts = curr_coverage + (artnum15plus[t][g] - curr_coverage) * DT / (1.0 - art_interp_w);
+		double artcov_hts = curr_coverage + (artnum15plus[t][g] - curr_coverage) * DT / (1.0 - art_interp_w + DT);
                 artnum_hts = artcov_hts * (Xart_15plus + Xartelig_15plus);
               }
             }

--- a/tests/testthat/helper_pjn_data.R
+++ b/tests/testthat/helper_pjn_data.R
@@ -1,1 +1,1 @@
-pjn_data <- read.csv("testdata/sao_tome_test.pjn.csv", as.is = TRUE)
+pjn_data <- first90_read_csv_character("testdata/sao_tome_test.pjn.csv")


### PR DESCRIPTION
This PR makes a few small patches that have arisen while Tim Brown implementing EPP-ASM.

* Use `vroom::vroom()` to read PJNZ files; much faster for reading `.DP` file.
* Handle Spectrum version numbers saved on Francophone locale devices: e.g. 6,13 instead of 6.13.
* In `read_specdp_demog_param()`, ensure no zero totals when normalising age-specific fertility 
  distribution and net-migration age distribution.
* Fix calculation for target number on treatment during transition from number to percent input.

The change from `read.csv()` to `vroom()` is just to speed up the read slightly.