### PR TITLE
implement Spectrum Adult ART adjustment

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: first90
-Version: 1.6.5
+Version: 1.6.6
 Title: The first90 model
 Description: Implements the Shiny90 model for estimating progress towards the UNAIDS "first 90" target for HIV awareness of status in sub-Saharan Africa.
 Authors@R:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# first90 1.6.6
+
+* Implement Spectrum Adult ART scalar adjustment. This is a user input that 
+  allows the input number on ART to be adjusted by a scalar to account for 
+  over/under-reporting of treatment numbers.
+
 # first90 1.6.5
 
 * Exclude NA values to set max `ylim` in `plot_prv_pos_yld()`. This addresses issue with this plot not showing in interface and preventing plot downloads when data NA values are simulated.

--- a/R/extract-pjnz.R
+++ b/R/extract-pjnz.R
@@ -107,7 +107,26 @@ extract_pjnz <- function(pjnz = NULL, dp_file= NULL, pjn_file = NULL){
   v$art15plus_numperc <- array(as.numeric(unlist(dpsub(dp, "<HAARTBySexPerNum MV>", 4:5, col_idx))), lengths(dn), dn)
   v$art15plus_num <- array(as.numeric(unlist(dpsub(dp, "<HAARTBySex MV>", 4:5, col_idx))), lengths(dn), dn)
   v$art15plus_needart <- array(as.numeric(unlist(dpsub(dp, "<NeedARTDec31 MV>", 3:4, col_idx))), lengths(dn), dn)
-  
+
+  ## # Adult on ART adjustment factor
+  ## 
+  ## * Implemented from around Spectrum 6.2 (a few versions before)
+  ## * Allows user to specify scalar to reduce number on ART in each year ("<AdultARTAdjFactor>")
+  ## * Enabled / disabled by checkbox flag ("<AdultARTAdjFactorFlag>")
+  ## * Scaling factor only applies to number inputs, not percentages (John Stover email, 20 Feb 2023)
+  ##   -> Even if scaling factor specified in a year with percentage input, ignore it.
+
+  if (exists_dptag(dp, "<AdultARTAdjFactorFlag>") &&
+        dpsub(dp, "<AdultARTAdjFactorFlag>", 2, 4) == 1) {
+
+    adult_artadj_factor <- array(as.numeric(unlist(dpsub(dp, "<AdultARTAdjFactor>", 3:4, col_idx))), lengths(dn), dn)
+
+    ## Only apply if is number (! is percentage)
+    adult_artadj_factor <- adult_artadj_factor ^ as.numeric(!v$art15plus_numperc)
+
+    v$art15plus_num <- v$art15plus_num * adult_artadj_factor
+  }
+
   v$art15plus_eligthresh <- setNames(as.numeric(dpsub(dp, "<CD4ThreshHoldAdults MV>", 2, col_idx)), proj_years)
 
   artelig_specpop <- setNames(dpsub(dp, "<PopsEligTreat MV>", 3:9, 2:6),


### PR DESCRIPTION
This implements the ART adjustment in Spectrum allowing user to specify a scalar to adjust input ART data for over/under counting. 

This currently affects Uganda, and may affect a few other countries in next week.

<img width="974" alt="image" src="https://user-images.githubusercontent.com/7427899/220188632-b7c74226-702a-4a14-bdc9-f2b42a1f2b7a.png">
