### PR TITLE
correct ART need 15plus for Spectrum 2023

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: first90
-Version: 1.6.6
+Version: 1.6.7
 Title: The first90 model
 Description: Implements the Shiny90 model for estimating progress towards the UNAIDS "first 90" target for HIV awareness of status in sub-Saharan Africa.
 Authors@R:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# first90 1.6.7
+
+* Update PJNZ extraction for adult ART need Dec 31 for 2023 PJNZ files. Previously child ART was
+  note recorded in the .DP file tag `<NeedARTDec31 MV>`, and so it was fine to extract the total
+  value. Now child ART is recorded, and so need to sum the adult age groups only.
+  
 # first90 1.6.6
 
 * Implement Spectrum Adult ART scalar adjustment. This is a user input that 

--- a/R/extract-pjnz.R
+++ b/R/extract-pjnz.R
@@ -103,10 +103,17 @@ extract_pjnz <- function(pjnz = NULL, dp_file= NULL, pjn_file = NULL){
   v$artmx_timerr <- get_dp_artmx_timerr(dp, proj_years)
   
   ## # ART programme data
-
   v$art15plus_numperc <- array(as.numeric(unlist(dpsub(dp, "<HAARTBySexPerNum MV>", 4:5, col_idx))), lengths(dn), dn)
   v$art15plus_num <- array(as.numeric(unlist(dpsub(dp, "<HAARTBySex MV>", 4:5, col_idx))), lengths(dn), dn)
-  v$art15plus_needart <- array(as.numeric(unlist(dpsub(dp, "<NeedARTDec31 MV>", 3:4, col_idx))), lengths(dn), dn)
+
+  male_15plus_needart <- dpsub(dp, "<NeedARTDec31 MV>", 4:17*3 + 3, col_idx)
+  male_15plus_needart <- vapply(lapply(male_15plus_needart, as.numeric), sum, numeric(1))
+
+  female_15plus_needart <- dpsub(dp, "<NeedARTDec31 MV>", 4:17*3 + 4, col_idx)
+  female_15plus_needart <- vapply(lapply(female_15plus_needart, as.numeric), sum, numeric(1))
+
+  v$art15plus_needart <- rbind(male_15plus_needart, female_15plus_needart)
+  dimnames(v$art15plus_needart) <- dn
 
   ## # Adult on ART adjustment factor
   ## 


### PR DESCRIPTION
Spectrum slightly changed the data saved in the .DP file tag  `<NeedARTDec31 MV>` in the 2023 Spectrum files.  Previously age 0-14 were not saved in this. Now they are. 

Consequently, can't simply take the totals to get ART need for age 15+, need to aggregate the 5-year age group values for the adult population only.

This affects the number on ART when entered as a percentage — in the projection period. Thus it should not affect model outputs for 2022 estimates; only 2023 onward (which are not generally used).