### PR TITLE
patch: net-migration in artpop in first ART year

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: first90
-Version: 1.6.8
+Version: 1.6.9
 Title: The first90 model
 Description: Implements the Shiny90 model for estimating progress towards the UNAIDS "first 90" target for HIV awareness of status in sub-Saharan Africa.
 Authors@R:
@@ -25,7 +25,7 @@ Encoding: UTF-8
 LazyData: true
 ByteCompile: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.3
 Depends:
     R (>= 2.10)
 Imports:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,8 @@
-# first90 1.6.7
+# first90 1.6.9
+
+* Bug fix: account for end-year net migration in the ART population in the first year of ART start (implemented in v1.6.0).
+
+# first90 1.6.8
 
 * Don't interpolate number aware outputs in Spectrum output table when using calendar year interpolation.
 

--- a/src/eppasm.cpp
+++ b/src/eppasm.cpp
@@ -1096,7 +1096,7 @@ extern "C" {
 	      pop[t][HIVP][g][a] += hmig_a;
 	      
 	      mig_ha += hmig_a;
-	      if (t > t_hts_start) {
+	      if (t >= t_hts_start) {
 		mig_hivn_ha += nmig_a;
 	      }
 	      a++;
@@ -1105,7 +1105,7 @@ extern "C" {
 	    // migration for hivpop
 	    double migrate_ha = hivpop_ha > 0 ? mig_ha / hivpop_ha : 0.0;
 	    
-	    if(t > t_hts_start) {
+	    if(t >= t_hts_start) {
 	      double migrate_hivn_ha = hivnpop_ha > 0 ? mig_hivn_ha / hivnpop_ha : 0.0;
 	      testnegpop[t][HIVN][g][ha] *= 1+migrate_hivn_ha;
 	      testnegpop[t][HIVP][g][ha] *= 1+migrate_ha;
@@ -1113,9 +1113,9 @@ extern "C" {
 
 	    for(int hm = 0; hm < hDS; hm++){
 	      hivpop[t][g][ha][hm] *= 1+migrate_ha;
-	      if(t > t_hts_start)
+	      if(t >= t_hts_start)
 		diagnpop[t][g][ha][hm] *= 1+migrate_ha;
-	      if(t > t_ART_start)
+	      if(t >= t_ART_start)
 		for(int hu = 0; hu < hTS; hu++)
 		  artpop[t][g][ha][hm][hu] *= 1+migrate_ha;
 	    } // loop over hm


### PR DESCRIPTION
There was a small error in the update to end-year net migration. It was only applied if t > t_ART_start, which was copied from when net migration occurred before the HIV model simulation. When it occurs after the HIV model simulation, this needs to be t >= t_ART_start.

In practice, this is of minimal consequence as the number on ART in the first year is small and net migration relatively small But it creates a discrepancy between the single-age HIV population and the sum of hivpop and artpop.