### PR TITLE
fixing bug in R version of eppasm.R

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: first90
-Version: 1.6.10
+Version: 1.6.11
 Title: The first90 model
 Description: Implements the Shiny90 model for estimating progress towards the UNAIDS "first 90" target for HIV awareness of status in sub-Saharan Africa.
 Authors@R:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# first90 1.6.11
+
+* Fix bug in R version of simmod() where new infections previously tested negative were
+  subtracted from (instead of added to) the hiv positive. Implementation in C++ version was 
+  correct (thanks Andrey Kutsyh).
+
 # first90 1.6.10
 
 * Implement recovery to next higher CD4 category following ART interruption for those on ART greater than one year.

--- a/R/eppasm.R
+++ b/R/eppasm.R
@@ -250,7 +250,7 @@ simmod <- function(fp, VERSION = "C") {
           testneg_infections_ha <- infections_ha * (testnegpop[,,hivn.idx,i] / hivn_pop_ha)
 
           grad_tn[ , , hivn.idx] <- grad_tn[ , , hivn.idx] - testneg_infections_ha
-          grad_tn[ , , hivp.idx] <- grad_tn[ , , hivp.idx] - testneg_infections_ha
+          grad_tn[ , , hivp.idx] <- grad_tn[ , , hivp.idx] + testneg_infections_ha
         }
 
         ## Do new diagnoses


### PR DESCRIPTION
Andrey was comparing the R and C version of `simmod()` in `eppasm.R`. He found a bug in the R version where we subtracting (instead of adding) from the hiv positives the new infections that were previously tested negative. 

(In the C++ version, we are processing them correctly.)