### PR TITLE
2025 update -- Spectrum ART adjustment and allocation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: first90
-Version: 1.7.0
+Version: 1.7.1
 Title: The first90 model
 Description: Implements the Shiny90 model for estimating progress towards the UNAIDS "first 90" target for HIV awareness of status in sub-Saharan Africa.
 Authors@R:

--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,10 @@
   application of the ratios; if the .DP file does not contain the checkbox 
   flag, then the ratio is applied.
   
+* Patch ART dropout implementation. Spectrum converts input ART dropout percent to an 
+  annual rate using [dropout rate] = -log(1.0 - [input percent]).
+  
+
 # first90 1.7.0
 
 * Update output plots and tables to 2024.

--- a/NEWS.md
+++ b/NEWS.md
@@ -19,7 +19,20 @@
   
 * Patch ART dropout implementation. Spectrum converts input ART dropout percent to an 
   annual rate using [dropout rate] = -log(1.0 - [input percent]).
+
+* Implement Spectrum ART allocation.
   
+  There has been a longstanding discrepancy betweeen EPP-ASM and Spectrum in ART allocation.
+  For ART allocation by 'expected mortality', EPP-ASM allocated according to mortality by CD4
+  and age.
+  
+  Spectrum allocates ART in a two step process: first, ART is allocated by CD4 category based
+  on the 'expected mortality' and 'proportional to eligibility' weight. Second, within 
+  CD4 categories, ART is allocated by age solely proportional to number in each age 
+  group (propotional to eligibility).
+  
+  This has modest overall difference, but was a source of numerical differences between 
+  Spectrum and EPP-ASM.
 
 # first90 1.7.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,22 @@
+# first90 1.7.1
+
+* Implement Spectrum adult ART adjustment by absolute count. This is a user 
+  input that adjust the number on ART count by an absolute value. It is
+  intended to be used to account for clients receiving services in or
+  from another region; typically with subnational Spectrum files.
+  
+  If both absolute count and ratio adjustments are specified in the same
+  year, the absolute count is applied first and then ratio is applied. 
+  If ART is specified as a percentage, then adjustments do not have any 
+  influence.
+  
+  Previously entered ART adjustments were applied or not via a checkbox in
+  Spectrum. The checkbox has been removed in Spectrum 6.38 beta 18. For 
+  backward compatability with previously simulated Spectrum outputs, if the 
+  checkbox flag exists in the .DP file, it is still used to determine 
+  application of the ratios; if the .DP file does not contain the checkbox 
+  flag, then the ratio is applied.
+  
 # first90 1.7.0
 
 * Update output plots and tables to 2024.

--- a/R/create_fp.R
+++ b/R/create_fp.R
@@ -131,9 +131,16 @@ create_fp <- function(projp,
   fp$art_mort <- projp$art_mort[,,projp.h.ag,]
   fp$artmx_timerr <- projp$artmx_timerr
 
-  fp$cd4_nonaids_excess_mort <- projp$cd4_nonaids_excess_mort[,projp.h.ag,]
+  if (!is.null(projp$cd4_nonaids_excess_mort)) {
+    fp$cd4_nonaids_excess_mort <- projp$cd4_nonaids_excess_mort[,projp.h.ag,]
+  } else {
+    fp$cd4_nonaids_excess_mort <- array(0.0, dim(fp$cd4_mort))
+  }
+  
   fp$art_nonaids_excess_mort <- array(0.0, dim(fp$art_mort))
-  fp$art_nonaids_excess_mort[] <- rep(projp$art_nonaids_excess_mort[,projp.h.ag,], each = hTS)
+  if (!is.null(projp$art_nonaids_excess_mort)) {
+    fp$art_nonaids_excess_mort[] <- rep(projp$art_nonaids_excess_mort[,projp.h.ag,], each = hTS)
+  }
 
   frr_agecat <- as.integer(rownames(projp$fert_rat))
   frr_agecat[frr_agecat == 18] <- 17

--- a/R/create_fp.R
+++ b/R/create_fp.R
@@ -177,8 +177,9 @@ create_fp <- function(projp,
     fp$art_dropout_recover_cd4 <- art_dropout_recover_cd4
   }
 
+  ## Convert input percent dropout in 12 months to an annual rate (Rob Glaubius email 25 July 2024)
+  fp$art_dropout <- -log(1.0 - projp$art_dropout[as.character(proj_start:proj_end)]/100)
   
-  fp$art_dropout <- projp$art_dropout[as.character(proj_start:proj_end)]/100
   fp$median_cd4init <- projp$median_cd4init[as.character(proj_start:proj_end)]
   fp$med_cd4init_input <- as.integer(fp$median_cd4init > 0)
   fp$med_cd4init_cat <- replace(findInterval(-fp$median_cd4init, - c(1000, 500, 350, 250, 200, 100, 50)),

--- a/R/eppasm.R
+++ b/R/eppasm.R
@@ -434,20 +434,41 @@ simmod <- function(fp, VERSION = "C") {
             }
 
           } else {
-            expect.mort.weight <- sweep(fp$cd4_mort[, h.age15plus.idx,], 3,
-                                        colSums(art15plus.elig * fp$cd4_mort[, h.age15plus.idx,],,2), "/")
-            artinit.weight <- sweep(fp$art_alloc_mxweight * expect.mort.weight, 3, (1 - fp$art_alloc_mxweight)/colSums(art15plus.elig,,2), "+")
-            artinit <- pmin(sweep(artinit.weight * art15plus.elig, 3, art15plus.inits, "*"),
-                            art15plus.elig, na.rm=TRUE)
 
-            ## ## Allocation by average mortality across CD4, trying to match Spectrum
-            ## artelig_by_cd4 <- apply(art15plus.elig, c(1, 3), sum)
-            ## expectmort_by_cd4 <- apply(art15plus.elig * fp$cd4_mort[, h.age15plus.idx,], c(1, 3), sum)
+            ## ## Old EPP-ASM implementation
+            ##
+            ## Applied 'expected mortality' weight within each cd4-age mortality strata.
+            ## Different from Spectrum.
+            ##             
+            ## expect.mort.weight <- sweep(fp$cd4_mort[, h.age15plus.idx,], 3,
+            ##                            colSums(art15plus.elig * fp$cd4_mort[, h.age15plus.idx,],,2), "/")       ## 
+            ## artinit.weight <- sweep(fp$art_alloc_mxweight * expect.mort.weight, 3, (1 - fp$art_alloc_mxweight)/colSums(art15plus.elig,,2), "+")
+            ## artinit <- pmin(sweep(artinit.weight * art15plus.elig, 3, art15plus.inits, "*"),
+            ##                 art15plus.elig, na.rm=TRUE)
 
-            ## artinit_dist <- (sweep(artelig_by_cd4, 2, colSums(artelig_by_cd4), "/") +
-            ##                  sweep(expectmort_by_cd4, 2, colSums(expectmort_by_cd4), "/")) / 2
-            ## artinit <- sweep(art15plus.elig, c(1, 3), sweep(artinit_dist / artelig_by_cd4, 2, art15plus.inits, "*"), "*")
-            ## artinit <- pmin(artinit, art15plus.elig, na.rm=TRUE)
+            ## Spectrum ART initiation is 2-step process
+            ## 1. Allocate by CD4 category (weighted by 'eligible' and 'expected mortality')
+            ## 2. Allocate by age groups (weighted only by eligibility)
+
+            ## First step: allocate initiation by CD4 category (_hm)
+            artelig_hm <- apply(art15plus.elig, c(1, 3), sum)
+            expected_deaths_hm <- apply(art15plus.elig * fp$cd4_mort[, h.age15plus.idx,], c(1, 3), sum)
+            expected.mort.weight_hm <- sweep(expected_deaths_hm, 2, colSums(expected_deaths_hm), "/")
+            artelig.weight_hm <- sweep(artelig_hm, 2, colSums(artelig_hm), "/")
+            
+            artinit.weight_hm <- fp$art_alloc_mxweight * expected.mort.weight_hm +
+              (1.0 - fp$art_alloc_mxweight) * artelig.weight_hm
+
+            artinit_hm <- sweep(artinit.weight_hm, 2, art15plus.inits, "*")
+
+            ## Second step: within each CD4 category, allocate initiation
+            ## proportionally by age
+            
+            ## Proportion initiating in each sex x CD4 category
+            artinit_prob <- artinit_hm / artelig_hm
+            artinit <- sweep(art15plus.elig, c(1, 3), artinit_prob, "*")
+
+            artinit <- pmin(artinit, art15plus.elig, na.rm=TRUE)
           }
 
         } else {

--- a/src/eppasm.cpp
+++ b/src/eppasm.cpp
@@ -852,13 +852,47 @@ extern "C" {
           // ART initiation
           for(int g = 0; g < NG; g++){
 
-            double artelig_hahm[hAG_15PLUS][hDS], Xart_15plus = 0.0, Xartelig_15plus = 0.0, expect_mort_artelig15plus = 0.0;
+	    // Spectrum ART allocation is 2-step process
+	    // 1. Allocate by CD4 category (weighted by 'eligible' and 'expected mortality')
+	    // 2. Allocate by age groups (weighted only by eligibility)
+	    //
+	    // The first step: allocate initiation by CD4 category (_hm) requires
+	    // tabulating number eligible and expected mortality within each CD4
+	    // category (aggregated over all ages).
+	    
+	    double Xart_15plus = 0.0; // Total currently on ART
+	    
+	    double artelig_hahm[hAG_15PLUS][hDS];
+	    double artelig_hm[hDS];
+	    double Xartelig_15plus = 0.0;
+	    
+	    double expect_mort_artelig_hm[hDS];
+	    double expect_mort_artelig15plus = 0.0;
+	    
+	    // Initialise to zero
+	    memset(artelig_hm, 0, hDS * sizeof(double));
+	    memset(expect_mort_artelig_hm, 0, hDS * sizeof(double));
+
             for(int ha = hIDX_15PLUS; ha < hAG; ha++){
               for(int hm = everARTelig_idx; hm < hDS; hm++){
+
                 if(hm >= anyelig_idx){
-                  double prop_elig = (hm >= cd4elig_idx) ? 1.0 : (hm >= hIDX_CD4_350) ? 1.0 - (1.0-specpop_percelig[t])*(1.0-who34percelig) : specpop_percelig[t];
-                  Xartelig_15plus += artelig_hahm[ha-hIDX_15PLUS][hm] = prop_elig * hivpop[t][g][ha][hm] ;
-                  expect_mort_artelig15plus += cd4_mort[g][ha][hm] * artelig_hahm[ha-hIDX_15PLUS][hm];
+
+		  // Specify proportion eligible
+		  double prop_elig = (hm >= cd4elig_idx) ? 1.0 :
+		    (hm >= hIDX_CD4_350) ?
+		    1.0 - (1.0-specpop_percelig[t]) * (1.0-who34percelig) :
+		    specpop_percelig[t];
+		  
+		  double artelig_hahm_tmp = prop_elig * hivpop[t][g][ha][hm];
+		  artelig_hahm[ha-hIDX_15PLUS][hm] = artelig_hahm_tmp;
+		  artelig_hm[hm] += artelig_hahm_tmp;
+		  Xartelig_15plus += artelig_hahm_tmp;
+		  
+		  double expect_mort_hahm = cd4_mort[g][ha][hm] * artelig_hahm_tmp;
+		  expect_mort_artelig_hm[hm] += expect_mort_hahm;
+		  expect_mort_artelig15plus += expect_mort_hahm;
+		  
                 }
                 for(int hu = 0; hu < hTS; hu++)
                   Xart_15plus += artpop[t][g][ha][hm][hu];
@@ -877,8 +911,12 @@ extern "C" {
                 for(int hm = anyelig_idx; hm < cd4elig_idx; hm++){
                   double pw_elig_hahm = births_by_ha[ha-hIDX_FERT] * frr_cd4[t][ha-hIDX_FERT][hm] * hivpop[t][g][ha][hm] / frr_pop_ha;
                   artelig_hahm[ha-hIDX_15PLUS][hm] += pw_elig_hahm;
+		  artelig_hm[hm] += pw_elig_hahm;		  
                   Xartelig_15plus += pw_elig_hahm;
-                  expect_mort_artelig15plus += cd4_mort[g][ha][hm] * pw_elig_hahm;
+		  
+		  double pw_expect_mort_hahm = cd4_mort[g][ha][hm] * pw_elig_hahm;
+		  expect_mort_artelig_hm[hm] += pw_expect_mort_hahm;
+                  expect_mort_artelig15plus += pw_expect_mort_hahm;
                 }
               }
             } // loop over ha
@@ -1035,6 +1073,14 @@ extern "C" {
 
             } else { // Use mixture of eligibility and expected mortality for initiation distribution
 
+	      // ART allocation step 1: allocate by CD4 stage
+	      double artinit_hm[hDS];
+	      for(int hm = anyelig_idx; hm < hDS; hm++){
+		artinit_hm[hm] = artinit_hts *
+		  ( (1.0 - art_alloc_mxweight) * artelig_hm[hm] / Xartelig_15plus +
+		    art_alloc_mxweight * expect_mort_artelig_hm[hm] / expect_mort_artelig15plus);
+	      }
+
               for(int ha = hIDX_15PLUS; ha < hAG; ha++) {
 
                 double new_diagn_ha = 0.0, undiagnosed_ha = 0.0;
@@ -1044,28 +1090,35 @@ extern "C" {
                     undiagnosed_ha += hivpop[t][g][ha][hm] - diagnpop[t][g][ha][hm];
 
                 for(int hm = anyelig_idx; hm < hDS; hm++){
-
-                  double artinit_hahm = artinit_hts * artelig_hahm[ha-hIDX_15PLUS][hm] * ((1.0 - art_alloc_mxweight)/Xartelig_15plus + art_alloc_mxweight * cd4_mort[g][ha][hm] / expect_mort_artelig15plus);
-                  if(Xartelig_15plus == 0)
-                    artinit_hahm =  0;
-                  if(artinit_hahm > artelig_hahm[ha-hIDX_15PLUS][hm])
-                    artinit_hahm = artelig_hahm[ha-hIDX_15PLUS][hm];
-
-                  if(t >= t_hts_start){
-                    double new_diagn = artinit_hahm > diagnpop[t][g][ha][hm] ? artinit_hahm - diagnpop[t][g][ha][hm] : 0;
-
-                    new_diagn_ha += new_diagn;
-                    diagnpop[t][g][ha][hm] -= artinit_hahm - new_diagn;
+		  
+		  // ART allocation step 2: within CD4 category, allocate
+		  // by age proportional to eligibility
+		  if (artelig_hm[hm] > 0.0) {
+		    
+		    double artinit_hahm = artinit_hm[hm] *
+		      artelig_hahm[ha-hIDX_15PLUS][hm] / artelig_hm[hm];
+		    
+		    if(artinit_hahm > artelig_hahm[ha-hIDX_15PLUS][hm])
+		      artinit_hahm = artelig_hahm[ha-hIDX_15PLUS][hm];
+		    if(artinit_hahm > hivpop[t][g][ha][hm] + DT * grad[g][ha][hm])
+		      artinit_hahm = hivpop[t][g][ha][hm] + DT * grad[g][ha][hm];
+		    
+		    if(t >= t_hts_start){
+		      double new_diagn = artinit_hahm > diagnpop[t][g][ha][hm] ? artinit_hahm - diagnpop[t][g][ha][hm] : 0;
+		      
+		      new_diagn_ha += new_diagn;
+		      diagnpop[t][g][ha][hm] -= artinit_hahm - new_diagn;
                     diagnoses[t][g][ha][hm] += new_diagn;
                     late_diagnoses[t][g][ha][hm] += new_diagn;
-                  }
-
-
-                  hivpop[t][g][ha][hm] -= artinit_hahm;
-                  artpop[t][g][ha][hm][ART0MOS] += artinit_hahm;
-                  artinits[t][g][ha][hm] += artinit_hahm;
-                }
-
+		    }
+		    
+		    
+		    hivpop[t][g][ha][hm] -= artinit_hahm;
+		    artpop[t][g][ha][hm][ART0MOS] += artinit_hahm;
+		    artinits[t][g][ha][hm] += artinit_hahm;
+		  }
+		}
+		
                 // Remove share of excess ART initiations from either diagnpop or testnegpop
                 if(t >= t_hts_start && new_diagn_ha > 0){
 


### PR DESCRIPTION
The first update in here adds new Spectrum feature for ART adjustment by absolute count. The second two are small fixes to align EPP-ASM simulation with Spectrum (small impact).

Also addresses backward compatibility issue with previously saved .shiny90 zip that resulted in error in Naomi tests (@r-ash ).

# first90 1.7.1

* Implement Spectrum adult ART adjustment by absolute count. This is a user 
  input that adjust the number on ART count by an absolute value. It is
  intended to be used to account for clients receiving services in or
  from another region; typically with subnational Spectrum files.
  
  If both absolute count and ratio adjustments are specified in the same
  year, the absolute count is applied first and then ratio is applied. 
  If ART is specified as a percentage, then adjustments do not have any 
  influence.
  
  Previously entered ART adjustments were applied or not via a checkbox in
  Spectrum. The checkbox has been removed in Spectrum 6.38 beta 18. For 
  backward compatability with previously simulated Spectrum outputs, if the 
  checkbox flag exists in the .DP file, it is still used to determine 
  application of the ratios; if the .DP file does not contain the checkbox 
  flag, then the ratio is applied.
  
* Patch ART dropout implementation. Spectrum converts input ART dropout percent to an 
  annual rate using [dropout rate] = -log(1.0 - [input percent]).

* Implement Spectrum ART allocation.
  
  There has been a longstanding discrepancy betweeen EPP-ASM and Spectrum in ART allocation.
  For ART allocation by 'expected mortality', EPP-ASM allocated according to mortality by CD4
  and age.
  
  Spectrum allocates ART in a two step process: first, ART is allocated by CD4 category based
  on the 'expected mortality' and 'proportional to eligibility' weight. Second, within 
  CD4 categories, ART is allocated by age solely proportional to number in each age 
  group (propotional to eligibility).
  
  This has modest overall difference, but was a source of numerical differences between 
  Spectrum and EPP-ASM.
